### PR TITLE
add python-django to oss Readme

### DIFF
--- a/oss/Readme.md
+++ b/oss/Readme.md
@@ -25,6 +25,7 @@
 - [python basic](./python-basic) – Hello world.
 - [python bottle](./python-bottle) – A python app using the Bottle microframework.
 - [python flask](./python-flask) – A simple python example using the Flask microframework.
+- [python django](./python-django) – A simple python example using the Django web framework.
 - [static basic](./static-basic) – Basic static site.
 - [static dir](./static-dir) – Basic static site with custom root directory.
 - [static error pages](./static-error-pages) – Custom error pages.


### PR DESCRIPTION
# What
- add python-django link in oss/Readme.md

# Why
- as part of this PR: https://github.com/apex/up-examples/pull/37 I forgot to add the python-django link in oss/Readme.md