### PR TITLE
Make sure Next.js javascript files load properly.

### DIFF
--- a/oss/node-next/next.config.js
+++ b/oss/node-next/next.config.js
@@ -1,0 +1,4 @@
+const upStage = process.env.UP_STAGE;
+module.exports = {
+  assetPrefix: upStage ? `/${upStage}` : ""
+};


### PR DESCRIPTION
Without this code change, Next.js assets don't load:

![image](https://user-images.githubusercontent.com/788827/31572566-47f284da-b05e-11e7-860e-37b0fa4adef4.png)

By configuring the `assetPrefix` based on the `UP_STAGE` environment variable, Next.js properly loads the assets from the correct subdirectory.

The related Next.js docs can be found at https://github.com/zeit/next.js#cdn-support-with-asset-prefix