### PR TITLE
Make `Makefile` more CI friendly

### DIFF
--- a/oss/node-8/Makefile
+++ b/oss/node-8/Makefile
@@ -1,2 +1,2 @@
 node-v8.4.0-linux-x64:
-	@curl -sL https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x64.tar.xz | tar x
+	@curl -sL https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x64.tar.gz | tar -xz


### PR DESCRIPTION
`xz` may not be present on CI systems, and `tar x` isn't necessarily supported on all distros of linux.
`tar -xz` seems to be supported on Linux and macOS.