### PR TITLE
chore: bump node 8 from 8.4.0 to 8.9.3 in oss example

### DIFF
--- a/oss/node-8/.upignore
+++ b/oss/node-8/.upignore
@@ -1,3 +1,3 @@
 *.lock
 *.md
-!node-v8.4.0-linux-x64
+!node-v8.9.3-linux-x64

--- a/oss/node-8/Makefile
+++ b/oss/node-8/Makefile
@@ -1,2 +1,2 @@
-node-v8.4.0-linux-x64:
-	@curl -sL https://nodejs.org/dist/v8.4.0/node-v8.4.0-linux-x64.tar.gz | tar -xz
+node-v8.9.3-linux-x64:
+	@curl -sL https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x64.tar.gz | tar -xz

--- a/oss/node-8/Readme.md
+++ b/oss/node-8/Readme.md
@@ -31,9 +31,9 @@ The `proxy.command` script is run inside Lambda to start your server. You can th
 ```json
 {
   "proxy": {
-    "command": "./node-v8.4.0-linux-x64/bin/node app.js"
+    "command": "./node-v8.9.3-linux-x64/bin/node app.js"
   }
 }
 ```
 
-Also note that `./node-v8.4.0-linux-x64` is placed in .gitignore so it's not checked into GIT. Up will ignore these by default, so we negate it with `!node-v8.4.0-linux-x64` in .upignore.
+Also note that `./node-v8.9.3-linux-x64` is placed in .gitignore so it's not checked into GIT. Up will ignore these by default, so we negate it with `!node-v8.9.3-linux-x64` in .upignore.

--- a/oss/node-8/up.json
+++ b/oss/node-8/up.json
@@ -4,7 +4,7 @@
     "build": "make"
   },
   "proxy": {
-    "command": "./node-v8.4.0-linux-x64/bin/node app.js"
+    "command": "./node-v8.9.3-linux-x64/bin/node app.js"
   },
   "lambda": {
     "memory": 1024


### PR DESCRIPTION
Bumped the node 8 version in the `oss/node-8` from `8.4.0` to `8.9.3`.