### PR TITLE
bump node version in node 8 & node-micro 

### DIFF
--- a/oss/node-8/.gitignore
+++ b/oss/node-8/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-node-v8.4.0-linux-x64
+node-v8.9.4-linux-x64

--- a/oss/node-8/.upignore
+++ b/oss/node-8/.upignore
@@ -1,3 +1,3 @@
 *.lock
 *.md
-!node-v8.9.3-linux-x64
+!node-v8.9.4-linux-x64

--- a/oss/node-8/Makefile
+++ b/oss/node-8/Makefile
@@ -1,2 +1,2 @@
-node-v8.9.3-linux-x64:
-	@curl -sL https://nodejs.org/dist/v8.9.3/node-v8.9.3-linux-x64.tar.gz | tar -xz
+node-v8.9.4-linux-x64:
+	@curl -sL https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.gz | tar -xz

--- a/oss/node-8/Readme.md
+++ b/oss/node-8/Readme.md
@@ -31,9 +31,9 @@ The `proxy.command` script is run inside Lambda to start your server. You can th
 ```json
 {
   "proxy": {
-    "command": "./node-v8.9.3-linux-x64/bin/node app.js"
+    "command": "./node-v8.9.4-linux-x64/bin/node app.js"
   }
 }
 ```
 
-Also note that `./node-v8.9.3-linux-x64` is placed in .gitignore so it's not checked into GIT. Up will ignore these by default, so we negate it with `!node-v8.9.3-linux-x64` in .upignore.
+Also note that `./node-v8.9.4-linux-x64` is placed in .gitignore so it's not checked into GIT. Up will ignore these by default, so we negate it with `!node-v8.9.4-linux-x64` in .upignore.

--- a/oss/node-8/up.json
+++ b/oss/node-8/up.json
@@ -4,7 +4,7 @@
     "build": "make"
   },
   "proxy": {
-    "command": "./node-v8.9.3-linux-x64/bin/node app.js"
+    "command": "./node-v8.9.4-linux-x64/bin/node app.js"
   },
   "lambda": {
     "memory": 1024

--- a/oss/node-micro/.gitignore
+++ b/oss/node-micro/.gitignore
@@ -1,4 +1,4 @@
-node-v8.9.0-linux-x64
+node-v8.9.4-linux-x64
 node_modules
 .DS_Store
 *.log

--- a/oss/node-micro/.upignore
+++ b/oss/node-micro/.upignore
@@ -1,3 +1,3 @@
-!node-v8.9.0-linux-x64
+!node-v8.9.4-linux-x64
 *.lock
 *.md

--- a/oss/node-micro/Makefile
+++ b/oss/node-micro/Makefile
@@ -1,2 +1,2 @@
-node-v8.9.0-linux-x64:
-	@curl -sL https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x64.tar.gz | tar -xz
+node-v8.9.4-linux-x64:
+	@curl -sL https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.gz | tar -xz

--- a/oss/node-micro/up.json
+++ b/oss/node-micro/up.json
@@ -4,7 +4,7 @@
     "build": "make"
   },
   "proxy": {
-    "command": "./node-v8.9.0-linux-x64/bin/node node_modules/.bin/micro --host localhost --port $PORT"
+    "command": "./node-v8.9.4-linux-x64/bin/node node_modules/.bin/micro --host localhost --port $PORT"
   },
   "lambda": {
     "memory": 1024


### PR DESCRIPTION
~~None of the bumps in `package.json` deps go beyond the range specified in the example, but bumping and regenerating `yarn.lock` should be useful for folks looking to pick up and go after cloning the repo.~~

The `node-spa` example has some severely outdated deps, especially after major changes in `neutrino` v8. I'd be glad to fix those if necessary.

The most consequential changes are in the `node-8` and `node-micro` examples, where node was bumped to the latest LTS in all relevant files (docs, `Makefile`s, `up.json` etc.).