### PR TITLE
Fix port in application.properties

### DIFF
--- a/oss/java-maven-springboot/src/main/resources/application.properties
+++ b/oss/java-maven-springboot/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.main.bannerMode=off
 spring.application.name=demo
-server.port=${port:3000}
+server.port=${PORT:3000}


### PR DESCRIPTION
The `PORT` env var is provided by up itself, however (at least in my testing) this is case sensitive.